### PR TITLE
exposed generate_morse_code and stream_morse_code for use as library

### DIFF
--- a/pycwgen/__init__.py
+++ b/pycwgen/__init__.py
@@ -1,0 +1,2 @@
+from .morse import generate_morse_code as generate
+from .morse import stream_morse_code as stream


### PR DESCRIPTION
I added references to `generate_morse_code` and `stream_morse_code` in `__init__.py` so that these functions can be used in code simply by installing it from pip.

I shortened the function names for the API since it is implied that the module generates morse code.